### PR TITLE
When building paths, use File.separator

### DIFF
--- a/src/com/gmail/trentech/pjw/utils/Zip.java
+++ b/src/com/gmail/trentech/pjw/utils/Zip.java
@@ -14,11 +14,11 @@ public class Zip {
 	public static void save(String zipFileName, File directory){
 		Main.getLog().info("Creating world backup..");
 		File backupDir = new File("backup");
-        if (!backupDir.isDirectory()) {
-        	backupDir.mkdirs();
-        }
-		
-		String zipFile = backupDir.getAbsolutePath() + "\\" + zipFileName + ".zip";
+        	if (!backupDir.isDirectory()) {
+        		backupDir.mkdirs();
+        	}
+
+		String zipFile = backupDir.getAbsolutePath() + File.separator + zipFileName + ".zip";
 
 		try {
 			FileOutputStream fileOutputStream = new FileOutputStream(zipFile);


### PR DESCRIPTION
A backslash character literal isn't portable.